### PR TITLE
fix pacakge bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@ionic-native/splash-screen": "3.12.1",
     "@ionic-native/status-bar": "3.12.1",
     "@ionic/storage": "2.0.1",
-    "apollo-angular": "1.0.0",
+    apollo-angular": "1.5.0",
     "apollo-angular-link-http": "1.0.1",
     "apollo-cache-inmemory": "^1.0.0",
     "apollo-client": "^2.0.1",
@@ -33,7 +33,7 @@
     "graphql-tag": "^2.5.0",
     "ionic-angular": "^3.8.0",
     "ionicons": "3.0.0",
-    "rxjs": "5.4.3",
+    "rxjs": "^5.5.2",
     "sw-toolbox": "3.6.0",
     "zone.js": "0.8.17"
   },


### PR DESCRIPTION
```
Typescript Error
Generic type 'FetchMoreQueryOptions<TVariables, K>' requires 2 type argument(s).
node_modules/apollo-angular/QueryRef.d.ts
refetch(variables?: any): Promise<ApolloQueryResult<T>>;
fetchMore(fetchMoreOptions: FetchMoreQueryOptions & FetchMoreOptions): Promise<ApolloQueryResult<T>>;
subscribeToMore(options: SubscribeToMoreOptions): () => void;
```

```
Typescript Error
Generic type 'UpdateQueryOptions<TVariables>' requires 1 type argument(s).
node_modules/apollo-angular/QueryRef.d.ts
subscribeToMore(options: SubscribeToMoreOptions): () => void;
updateQuery(mapFn: (previousQueryResult: any, options: UpdateQueryOptions) => any): void;
stopPolling(): void;
```

```
Cannot find module 'rxjs/operators/map' 
```